### PR TITLE
try Skia

### DIFF
--- a/build/build.rb
+++ b/build/build.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 # $:.unshift(File.expand_path("./dopebuild", __dir__))
 # require 'pry'
-# require 'debug'
+require 'debug'
 
 require_relative './dopebuild.rb'
 
@@ -13,12 +13,25 @@ conf.require_lib!('sdl2')
 conf.require_lib!('freetype2')
 conf.require_lib!('cairo')
 
+# To use this:
+# Download prebuilt Skia binaries here: https://github.com/JetBrains/skia-pack/releases
+# e.g. Skia-m132-a00c390e98-1-macos-Debug-arm64.zip
+# then unzip it into under ~/Downloads/_skia
+#
+conf.require_lib_2!('skia', "#{ENV['HOME']}/Downloads/_skia", [
+  ''
+],
+['out/Debug-macos-arm64'],
+[
+  'skia'
+])
+
 # include_video = (ENV['WITH_VIDEO'] == 'true')
 
 conf.build_files = [
-  'font.c',
+  'font.cpp',
   'layer_ext.c',
-  'surface.c',
+  'surface.cpp',
   'window.c',
   'timer.c',
 ]

--- a/examples/gen_video/main.rb
+++ b/examples/gen_video/main.rb
@@ -79,7 +79,7 @@ class GenApp
     @particles.each do |par|
       @sf.identity
       @sf.translate(par[:x] + 32, par[:y] + 32)
-      @sf.rotate(par[:life] * Math::PI * 2.0)
+      # @sf.rotate(par[:life] * Math::PI * 2.0)
       @sf.blit_surface(par[:sprite], -32, -32)
     end
     @sf.identity

--- a/ext/font.cpp
+++ b/ext/font.cpp
@@ -254,7 +254,11 @@ static VALUE
 t_font_size_set(VALUE self, VALUE _size) {
   DECLAREFONT(self);
   font->size = (float)NUM2DBL(_size);
-  FT_Set_Char_Size(font->face, 0, (int)(font->size * 64.0), 128, 128);
+  FT_Set_Char_Size((FT_Face)font->face,
+    (FT_F26Dot6)0,
+    (FT_F26Dot6)(font->size * 64.0),
+    (FT_UInt)128,
+    (FT_UInt)128);
   return Qnil;
 }
 
@@ -277,6 +281,7 @@ static VALUE t_font__color_set(VALUE self, VALUE _value) {
 
 ////////////////////////////////////////////////////////////////////////
 
+extern "C"
 void
 LAO_Font_Init() {
   cLayerFont = rb_define_class_under(cLayer, "Font", rb_cObject);

--- a/ext/surface.h
+++ b/ext/surface.h
@@ -14,8 +14,16 @@ struct LAO_Surface {
   int borrowed;
 };
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 VALUE lao_sfc_create_borrowed(SDL_Surface *sdl_surface, cairo_surface_t *cairo_surface, cairo_t *cairo_ctx);
 
 struct LAO_Surface *lao_sfc_from_value(VALUE v);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif


### PR DESCRIPTION
- getting a lot of segfaults, Skia lacks documentation, not widely used (yeah it's used everywhere but mostly indirectly like e.g. by chromium, so not a lots of examples online)
- building it from scratch is a pain, so I went with prebuilt binaries provided by https://github.com/JetBrains/skia-pack
- I tried using chatgpt o4-mini-high to get a drawing using Skia, but it hallucinates way too much
- unsure about the benefits of using it. Drawing rotated pictures with Cairo is painfully slow, but there's no evidence that Skia will do better unless of course it uses hardware (e.g. opengl) but I want to avoid using GPUs

A few useful links:

- how to build skia from scratch: https://skia.org/docs/user/download/
- skia fiddle: https://fiddle.skia.org/
- reference docs, like for SkCanvas: https://skia.org/docs/user/api/skcanvas_overview/
- user docs (almost useless): https://skia.org/docs/user/
